### PR TITLE
Use debugbreak library instead of `int3` for multi-architecture support

### DIFF
--- a/loadsf2.c
+++ b/loadsf2.c
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <signal.h>
 
+#include "debugbreak.h"
+
 struct sfSFBK sf2;  /* pointers to everything loaded go here */
 extern int verbose;
 
@@ -131,8 +133,8 @@ int main(int argc, char **argv)
 {
   if (argc > 1) {
     load_sf2(argv[1]);
-    signal (SIGTRAP, SIG_IGN); // if not debugging, ignore the int3
-    asm volatile ("int3");
+    signal (SIGTRAP, SIG_IGN); // if not debugging, ignore the break
+    debug_break();
   }
   exit(0);
 }

--- a/patchdump.c
+++ b/patchdump.c
@@ -13,6 +13,8 @@
 #include <stdio.h>
 #include <signal.h>
 
+#include "debugbreak.h"
+
 /* parse dump from 0xf0 to 0xf7, return pointer to just after last byte */
 /*
   patches: 0c 00 01
@@ -97,8 +99,8 @@ int main(int argc, char **argv)
 {
   if (argc > 1) {
     load_dump(argv[1]);
-    //signal (SIGTRAP, SIG_IGN); // if not debugging, ignore the int3
-    //asm volatile ("int3");
+    //signal (SIGTRAP, SIG_IGN); // if not debugging, ignore the break
+    //debug_break();
   }
   exit(0);
 }


### PR DESCRIPTION
The `int3` instruction is only supported on `x86` and `x86_64`, causing this to fail to build on other architectures, such as `aarch64`. By using the [debugbreak](https://github.com/scottt/debugbreak) library instead, it can build on many different architectures.