### PR TITLE
Fix MacOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: C/C++ CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,3 @@ jobs:
         sudo apt-get -y --no-install-recommends install libsdl2-dev
     - name: make
       run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y --no-install-recommends install libsdl2-dev
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: configure
-      run: ./configure
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,20 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ['ubuntu', 'macos']
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v4
-    - name: install dependencies
+    - name: install dependencies (linux)
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get -y --no-install-recommends install libsdl2-dev
+    - name: install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install sdl2
     - name: make
       run: make

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 ifeq ($(shell uname -s),Darwin)
- INCLUDES = -I/Library/Frameworks/SDL2.framework/Headers -F/Library/Frameworks
- SDL =  -F/Library/Frameworks -framework SDL2
  MIDIDEP = coremidi.o
  MIDILIB = -framework CoreMIDI -framework CoreFoundation
 else
- INCLUDES = $(shell sdl2-config --cflags)
- SDL = $(shell sdl2-config --libs)
  MIDIDEP = alsamidi.o
  MIDILIB = -lasound
 endif
+INCLUDES = $(shell sdl2-config --cflags)
+SDL = $(shell sdl2-config --libs)
 CFLAGS = -O2 -Wall -Wno-multichar -g $(INCLUDES)
 TFLAGS = -DTEST_TARGET
 LDFLAGS = -lm -lncurses $(SDL) $(MIDILIB)

--- a/loadsf2.c
+++ b/loadsf2.c
@@ -8,8 +8,8 @@
  * CFLAGS += -Wno-multichar
  */
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_audio.h"
+#include "SDL.h"
+#include "SDL_audio.h"
 #include "soundfont2.h"
 
 #include <stdio.h>

--- a/patchdump.c
+++ b/patchdump.c
@@ -7,8 +7,8 @@
  * 
  */
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_audio.h"
+#include "SDL.h"
+#include "SDL_audio.h"
 
 #include <stdio.h>
 #include <signal.h>

--- a/playmidi.h
+++ b/playmidi.h
@@ -8,8 +8,8 @@
 
 #define RELEASE "Playmidi 2.9"
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_audio.h"
+#include "SDL.h"
+#include "SDL_audio.h"
 
 #include "soundfont2.h"
 

--- a/readmidi.c
+++ b/readmidi.c
@@ -15,7 +15,7 @@
    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  *************************************************************************/
 #include "playmidi.h"
-#include "SDL2/SDL.h"
+#include "SDL.h"
 
 int format, ntrks, division;
 unsigned char *midifilebuf;


### PR DESCRIPTION
Fixes Mac builds. Includes most of #5 and ARM builds will fail until #4 is resolved. This required some changes to include paths because MacOS wasn't finding SDL when the include paths are prefixed with `SDL2`. I haven't tested this with a non-brew distribution of libsdl yet, so that should be tested at some point, and I also haven't tested if the changes to the include paths break Linux builds, so that should be tested as well.